### PR TITLE
Fix defaults, envvar and config processing

### DIFF
--- a/sargeparse/_parser/parser.py
+++ b/sargeparse/_parser/parser.py
@@ -66,16 +66,23 @@ class Parser:
     def add_set_defaults_kwargs(self, **kwargs):
         self.custom_parameters['defaults'].update(kwargs)
 
-    def callback_mask(self):
+    def parser_label(self):
+        return '_parser_{}'.format(id(self))
+
+    def callback_label(self):
         return '_callback_{}'.format(id(self))
 
-    def default_mask(self):
+    def defaults_label(self):
         return '_defaults_{}'.format(id(self))
 
-    def get_set_default_kwargs_masked(self):
-        kwargs = {self.default_mask(): self.set_defaults_kwargs}
+    def get_set_default_kwargs(self):
+        kwargs = {}
+
+        kwargs[self.parser_label()] = True
+        kwargs[self.defaults_label()] = self.set_defaults_kwargs
+
         if self.callback:
-            kwargs[self.callback_mask()] = self.callback
+            kwargs[self.callback_label()] = self.callback
 
         return kwargs
 

--- a/test/acceptance/test_sarge.py
+++ b/test/acceptance/test_sarge.py
@@ -132,3 +132,72 @@ def test_full_ok(caplog):
 
     for param in ['debug', 'x', 'flag']:
         assert "Missing 'help' in {}".format(param) in caplog.text
+
+
+def test_envvar_default_config_same_name_many_subcommands():
+
+    parser = sargeparse.Sarge({})
+
+    parser.add_subcommands({
+        'name': 'suba',
+        'arguments': [
+            {
+                'names': ['--arg1'],
+                'envvar': 'VARA'
+            },
+            {
+                'names': ['--arg2'],
+                'default': '2A'
+            },
+            {
+                'names': ['--arg3'],
+                'config_path': 'confA'
+            },
+        ],
+    }, {
+        'name': 'subb',
+        'arguments': [
+            {
+                'names': ['--arg1'],
+                'envvar': 'VARB'
+            },
+            {
+                'names': ['--arg2'],
+                'default': '2B'
+            },
+            {
+                'names': ['--arg3'],
+                'config_path': 'confB'
+            },
+        ],
+    })
+
+    def get_config(_args):
+        return {
+            'confA': '3A',
+            'confB': '3B',
+        }
+
+    sys.argv = shlex.split('test suba')
+    os.environ['VARA'] = '1A'
+    os.environ['VARB'] = '1B'
+
+    args = parser.parse(read_config=get_config)
+
+    assert args == ChainMap(
+        {},
+        {},
+        {
+            'arg1': '1A',
+        },
+        {
+            'arg3': '3A',
+        },
+        {
+            'arg2': '2A',
+        },
+        {
+            'arg1': sargeparse.unset,
+            'arg2': sargeparse.unset,
+        }
+    )


### PR DESCRIPTION
Before:
After CLI argument parsing, Sarge would traverse all the _Parser_s (deep-first-search) and setup defaults, envvars and config appropriately. The problem is, since all _Parser_s were traverser a _Parser_ that wasn't used could modify the values that a _Parser_ that was used, if it came later during the definition.

Now:
A parser label is injected via _set_defaults_, that way values are read only from the _Parser_s that were used.