### PR TITLE
Better parser data in callbacks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -320,7 +320,7 @@ max-statements=120
 max-parents=12
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=12
+max-attributes=16
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2

--- a/sargeparse/_parser/parser.py
+++ b/sargeparse/_parser/parser.py
@@ -13,7 +13,7 @@ from sargeparse._parser.group import ArgumentGroup, MutualExclussionGroup
 LOG = logging.getLogger(__name__)
 
 
-class Parser:  # pylint: disable=too-many-instance-attributes
+class Parser:
     def __init__(self, definition, **kwargs):
         definition = definition.copy()
 

--- a/sargeparse/_parser/parser.py
+++ b/sargeparse/_parser/parser.py
@@ -1,3 +1,4 @@
+import sys
 import textwrap
 import logging
 
@@ -28,6 +29,7 @@ class Parser:
             'callback': definition.pop('callback', None),
             'add_usage_to_parent_command_desc': definition.pop('add_usage_to_parent_command_desc', False),
             'group_descriptions': definition.pop('group_descriptions', {}),
+            'print_help_and_exit_if_last': definition.pop('print_help_and_exit_if_last', False),
             'add_help': definition.pop('add_help', True),
             'defaults': definition.pop('defaults', {}),
             'subparser': definition.pop('subparser', {}),
@@ -150,11 +152,19 @@ class Parser:
             self._process_custom_parameters_for_subcommand()
 
     def _process_common_custom_parameters(self):
-        if self.callback is not None and not callable(self.callback):
+        if self.callback and self.custom_parameters['print_help_and_exit_if_last']:
+            raise ValueError("'callback' and 'print_help_and_exit_if_last' are mutually exclusive")
+
+        if self.custom_parameters['print_help_and_exit_if_last']:
+            self.callback = self._make_print_help_and_exit_if_last_function()
+
+        if not self.callback:
+            self.callback = (lambda ctx: ctx.return_value)
+
+        if not callable(self.callback):
             raise TypeError("'callback' is not callable")
 
-        if self.callback:
-            self.callback.parser = self
+        self.callback.parser = self
 
     def _process_custom_parameters_for_main_command(self):
         if self.add_usage_to_parent_command_desc:
@@ -162,6 +172,17 @@ class Parser:
 
     def _process_custom_parameters_for_subcommand(self):
         pass
+
+    @staticmethod
+    def _make_print_help_and_exit_if_last_function():
+        def fn(ctx):
+            if not ctx.last:
+                return None
+
+            print(ctx.parser.help, file=sys.stderr)
+            return sargeparse.die(0)
+
+        return fn
 
     def _log_warning_if_command_has_positional_arguments_and_subparsers(self):
         if self._show_warnings and self._has_positional_arguments and self.subparsers:

--- a/sargeparse/_parser/parser.py
+++ b/sargeparse/_parser/parser.py
@@ -153,6 +153,9 @@ class Parser:
         if self.callback is not None and not callable(self.callback):
             raise TypeError("'callback' is not callable")
 
+        if self.callback:
+            self.callback.parser = self
+
     def _process_custom_parameters_for_main_command(self):
         if self.add_usage_to_parent_command_desc:
             raise TypeError("'add_usage_to_parent_command_desc' parameter applies only to subcommands")

--- a/sargeparse/custom.py
+++ b/sargeparse/custom.py
@@ -6,7 +6,7 @@ import shutil
 
 class ArgumentParser(argparse.ArgumentParser):
     def error(self, message):
-        sys.stderr.write('error: {}\n\n'.format(message))
+        print('error: {}\n\n'.format(message), file=sys.stderr)
         self.print_usage()
         sys.exit(2)
 

--- a/sargeparse/custom.py
+++ b/sargeparse/custom.py
@@ -6,7 +6,7 @@ import shutil
 
 class ArgumentParser(argparse.ArgumentParser):
     def error(self, message):
-        print('error: {}\n\n'.format(message), file=sys.stderr)
+        print('error: {}\n\n'.format(message), file=sys.stderr, end='')
         self.print_usage()
         sys.exit(2)
 

--- a/sargeparse/sarge.py
+++ b/sargeparse/sarge.py
@@ -284,7 +284,7 @@ class _ArgumentParserWrapper:
 
             parser_data.update(new_parser.add_subcommands(
                 *subparser.subparsers,
-                add_subparsers_kwargs=subparser.add_subparsers_kwargs,
+                add_subparsers_kwargs=subparser.add_subparsers_kwargs
             ))
 
             self._add_subcommand_usage_to_description(subparser, new_parser)

--- a/sargeparse/sarge.py
+++ b/sargeparse/sarge.py
@@ -192,7 +192,7 @@ class Sarge(SubCommand):
         # Add subcommands
         parser_data = apw.add_subcommands(
             *self._parser.subparsers,
-            add_subparsers_kwargs=self._parser.add_subparsers_kwargs,
+            add_subparsers_kwargs=self._parser.add_subparsers_kwargs
         )
         if self._parser.subparsers and self.help_subcommand:
             apw.add_subcommands(self._make_help_subparser(), add_subparsers_kwargs={})

--- a/sargeparse/sarge.py
+++ b/sargeparse/sarge.py
@@ -14,6 +14,14 @@ from sargeparse._parser import (
 )
 
 
+def format_parser_data(arg_parser):
+    return {
+        'prog': arg_parser.prog,
+        'help': arg_parser.format_help(),
+        'usage': arg_parser.format_usage(),
+    }
+
+
 class SubCommand:
     def __init__(self, definition, **kwargs):
         definition = definition.copy()
@@ -130,7 +138,9 @@ class Sarge(SubCommand):
 
         self._data.clear_all()
 
-        cli_args, arg_parser = self._parse_cli_arguments(argv)
+        cli_args, parser_data = self._parse_cli_arguments(argv)
+        self._data.parser_data = parser_data
+
         self._data.cli.update(cli_args)
         self._data._remove_unset_from_data_sources_cli()
         self._data._move_defaults_from_data_sources_cli()
@@ -144,8 +154,6 @@ class Sarge(SubCommand):
 
         self._data._parse_callbacks()
         self._data._remove_parser_key_from_data_sources_cli()
-
-        self._data._set_parser_data(arg_parser)
 
         return self._data
 
@@ -182,15 +190,20 @@ class Sarge(SubCommand):
         apw.add_arguments(*arguments)
 
         # Add subcommands
-        apw.add_subcommands(*self._parser.subparsers,
-                            add_subparsers_kwargs=self._parser.add_subparsers_kwargs)
+        parser_data = apw.add_subcommands(
+            *self._parser.subparsers,
+            add_subparsers_kwargs=self._parser.add_subparsers_kwargs,
+        )
         if self._parser.subparsers and self.help_subcommand:
             apw.add_subcommands(self._make_help_subparser(), add_subparsers_kwargs={})
 
         # Finish parsing args
         parsed_args = apw.parse_args(rest, parsed_args)
 
-        return parsed_args.__dict__, ap
+        # Add parser data
+        parser_data[self._parser.parser_key()] = format_parser_data(ap)
+
+        return parsed_args.__dict__, parser_data
 
     def _make_help_subparser(self):
         parser = Parser(
@@ -253,6 +266,8 @@ class _ArgumentParserWrapper:
         )
 
     def add_subcommands(self, *subparsers, add_subparsers_kwargs):
+        parser_data = {}
+
         for subparser in subparsers:
 
             self.setup_subparsers(**add_subparsers_kwargs)
@@ -267,10 +282,16 @@ class _ArgumentParserWrapper:
             arguments = subparser.compile_argument_list()
             new_parser.add_arguments(*arguments)
 
-            new_parser.add_subcommands(*subparser.subparsers,
-                                       add_subparsers_kwargs=subparser.add_subparsers_kwargs)
+            parser_data.update(new_parser.add_subcommands(
+                *subparser.subparsers,
+                add_subparsers_kwargs=subparser.add_subparsers_kwargs,
+            ))
 
             self._add_subcommand_usage_to_description(subparser, new_parser)
+
+            parser_data[subparser.parser_key()] = format_parser_data(new_parser.parser)
+
+        return parser_data
 
     def _add_subcommand_usage_to_description(self, subparser, new_parser):
         if not subparser.add_usage_to_parent_command_desc:

--- a/test/acceptance/test_dispatcher.py
+++ b/test/acceptance/test_dispatcher.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 import sys
 import shlex
+import re
 
 from collections import ChainMap
 
@@ -24,7 +25,7 @@ def test_callback_dispatch_with_decorators():
         'value': 1
     }
 
-    obj_sub_deco = {
+    obj_sb_dec = {
         'last': False,
         'value': 1
     }
@@ -36,6 +37,9 @@ def test_callback_dispatch_with_decorators():
         assert ctx.data['arg2'] == 'A2'
 
         assert ctx.return_value == 10
+        assert ctx.parser.prog == 'test sub'
+        assert re.match(r'\s*usage:\s+test sub.*$', ctx.parser.usage)
+        assert all(s not in ctx.parser.help for s in ('deco', 'sb_dec'))
 
     @sargeparse.Sarge.decorator({
         'arguments': [
@@ -57,6 +61,9 @@ def test_callback_dispatch_with_decorators():
     def parser(ctx):
         assert ctx.last == ctx.obj['last']
         assert ctx.return_value is None
+        assert ctx.parser.prog == 'test'
+        assert re.match(r'\s*usage:\s+test.*$', ctx.parser.usage)
+        assert all(s in ctx.parser.help for s in ('sub', 'deco', 'sb_dec'))
 
         if ctx.last:
             assert ctx.data['arg1'] == 'A1'
@@ -90,8 +97,13 @@ def test_callback_dispatch_with_decorators():
         assert ctx.data['arg2'] == 'A2'
         assert ctx.data['arg3'] == 'A3'
 
+        assert ctx.return_value == 10
+        assert ctx.parser.prog == 'test deco'
+        assert re.match(r'\s*usage:\s+test deco.*$', ctx.parser.usage)
+        assert all(s not in ctx.parser.help for s in ('sub', 'sb_dec'))
+
     @sargeparse.SubCommand.decorator({
-        'name': 'sub_deco',
+        'name': 'sb_dec',
         'arguments': [
             {
                 'names': ['--arg4'],
@@ -99,14 +111,19 @@ def test_callback_dispatch_with_decorators():
             },
         ]
     })
-    def sub_deco(ctx):
+    def sb_dec(ctx):
         assert ctx.last is True
         assert ctx.obj['value'] == 2
         assert ctx.data['arg1'] == 'A1'
         assert ctx.data['arg2'] == 'A2'
         assert ctx.data['arg4'] == 'A4'
 
-    parser.add_subcommands(sub_deco)
+        assert ctx.return_value == 10
+        assert ctx.parser.prog == 'test sb_dec'
+        assert re.match(r'\s*usage:\s+test sb_dec.*$', ctx.parser.usage)
+        assert all(s not in ctx.parser.help for s in ('sub', 'deco'))
+
+    parser.add_subcommands(sb_dec)
 
     sys.argv = shlex.split('test')
     args = parser.parse()
@@ -168,10 +185,10 @@ def test_callback_dispatch_with_decorators():
         },
     )
 
-    sys.argv = shlex.split('test sub_deco')
+    sys.argv = shlex.split('test sb_dec')
     args = parser.parse()
-    assert args.callbacks == [parser.__call__.fn, sub_deco.__call__.fn]
-    args.dispatch(obj=obj_sub_deco)
+    assert args.callbacks == [parser.__call__.fn, sb_dec.__call__.fn]
+    args.dispatch(obj=obj_sb_dec)
     assert args == ChainMap(
         {
             'arg2': 'A2',

--- a/test/unit/test_custom.py
+++ b/test/unit/test_custom.py
@@ -63,4 +63,3 @@ def test_subcommand_indentation(capsys):
     match = re.search(r'^(?P<indent>\s+)sub\s+SUBC_HELP\s*$', captured.out, re.MULTILINE)
     assert match
     assert match.group('indent') == indent
-


### PR DESCRIPTION
`ctx.parser` now contains data associated to the current subcommand (used to be general)

Plus, added the `'print_help_and_exit_if_last'` option so that commands/subcommands that are parents to more subcommands, can print help and exit if no subcommand was specified